### PR TITLE
Fix snippet logger entry indexing

### DIFF
--- a/_SnippetLogger.ahk
+++ b/_SnippetLogger.ahk
@@ -133,12 +133,21 @@ class ClipboardLogger {
             
             FileDelete(this.getFullPath(filename))
             this.listView.Delete(this.selectedIndex)
-            this.entries.Delete(this.selectedIndex)
+            this.rebuildEntries()
             this.selectedIndex := 0
             this.statusText.Value := "Entry deleted: " filename
         } catch Error as err {
             this.statusText.Value := "Error deleting entry: " err.Message
         }
+    }
+
+    rebuildEntries() {
+        newEntries := Map()
+        Loop this.listView.GetCount() {
+            idx := A_Index
+            newEntries[idx] := this.listView.GetText(idx, 3)
+        }
+        this.entries := newEntries
     }
     
     viewSelected(*) {


### PR DESCRIPTION
## Summary
- ensure entries map updates after deleting a listview row
- rebuild `entries` to sync indices with list view

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_683f98d72218832b9a8858b227911d4a